### PR TITLE
Add sonar-project.properties for code analysis exclusions

### DIFF
--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,0 +1,1 @@
+sonar.exclusions=tests/**,docs/**,node_modules/**


### PR DESCRIPTION
This file specifies exclusions for SonarQube analysis, ignoring tests, documentation, and node_modules directories. It helps streamline the analysis by focusing only on relevant source code.